### PR TITLE
Fix New Architecture bridgeless compatibility

### DIFF
--- a/android/src/main/java/com/poberwong/launcher/VibrateUtilsModule.java
+++ b/android/src/main/java/com/poberwong/launcher/VibrateUtilsModule.java
@@ -46,9 +46,9 @@ public class VibrateUtilsModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void vibrate(long milliseconds) {
+    public void vibrate(double milliseconds) {
         try {
-            VibrateUtils.vibrate(milliseconds);
+            VibrateUtils.vibrate((long) milliseconds);
         } catch (Exception e) {
 
         }


### PR DESCRIPTION
This fixes compatibility with the New Architecture's bridgeless mode introduced in React Native 0.74